### PR TITLE
Do not use labels for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels: []


### PR DESCRIPTION
Based on the [dependabot docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#configuration-options-for-updates) I must define `package-ecosystem`, `directory`, and `schedule` when defining a `dependabot.yml` (even though this is unnecessary in general, as seen by #3 existing).

My only reason for defining `dependabot.yml` is to ensure that dependabot doesn't label its PRs (since this is in all likelihood unnecessary and clutters up our label standardization).