### PR TITLE
Transfer all `conda-content-trust` logic from `conda`

### DIFF
--- a/conda_content_trust/api.py
+++ b/conda_content_trust/api.py
@@ -1,0 +1,188 @@
+from functools import lru_cache
+from glob import glob
+import json
+from logging import getLogger
+from os import makedirs
+from os.path import basename, isdir, join, exists
+from typing import Optional
+import warnings
+
+from conda.base.context import context
+from conda.common.url import join_url
+from conda.gateways.connection import HTTPError, InsecureRequestWarning
+from conda.gateways.connection.session import CondaSession
+
+from .authentication import verify_root, verify_delegation
+from .common import load_metadata_from_file, write_metadata_to_file, SignatureError
+from .constants import INITIAL_TRUST_ROOT, KEY_MGR_FILE
+from .signing import wrap_as_signable
+
+
+log = getLogger(__name__)
+
+
+class MetadataSignatureStatus:
+    def __init__(self):
+        if not isdir(context.av_data_dir):
+            log.info("creating directory for artifact verification metadata")
+            makedirs(context.av_data_dir)
+
+    @property
+    @lru_cache
+    def trusted_root(self):
+        # TODO: formalize paths for `*.root.json` and `key_mgr.json` on server-side
+        trusted = INITIAL_TRUST_ROOT
+
+        # Load current trust root metadata from filesystem
+        for path in sorted(glob(join(context.av_data_dir, "[0-9]*.root.json")), reverse=True):
+            try:
+                int(basename(path).split(".")[0])
+            except ValueError:
+                # prefix is not an int and is consequently an invalid file, skip to the next
+                pass
+            else:
+                log.info(f"Loading root metadata from {path}.")
+                trusted = load_metadata_from_file(path)
+                break
+        else:
+            log.debug(
+                f"No root metadata in {context.av_data_dir}. "
+                "Using built-in root metadata."
+            )
+
+        # Refresh trust root metadata
+        while True:
+            # TODO: caching mechanism to reduce number of refresh requests
+            fname = f"{trusted['signed']['version'] + 1}.root.json"
+            path = join(context.av_data_dir, fname)
+
+            # log.info(f"Fetching updated trust root if it exists: {self.channel.base_url}/{fname}")
+
+            try:
+                # TODO: support fetching root data with credentials
+                untrusted = fetch_channel_signing_data(
+                    context.signing_metadata_url_base,
+                    fname,
+                )
+
+                verify_root(trusted, untrusted)
+            except HTTPError as err:
+                # HTTP 404 implies no updated root.json is available, which is
+                # not really an "error" and does not need to be logged.
+                if err.response.status_code != 404:
+                    log.error(err)
+                break
+            except Exception as err:
+                # TODO: more error handling
+                log.error(err)
+                break
+            else:
+                # New trust root metadata checks out
+                trusted = untrusted
+                write_metadata_to_file(trusted, path)
+
+        return trusted
+
+    @property
+    @lru_cache
+    def key_mgr(self):
+        trusted = None
+
+        # Refresh key manager metadata
+        fname = KEY_MGR_FILE
+        path = join(context.av_data_dir, fname)
+
+        # log.info(f"Fetching updated key manager if it exists: {self.channel.base_url}/{fname}")
+
+        try:
+            untrusted = fetch_channel_signing_data(
+                context.signing_metadata_url_base,
+                KEY_MGR_FILE,
+            )
+
+            verify_delegation("key_mgr", untrusted, self.trusted_root)
+        except (ConnectionError, HTTPError) as err:
+            log.warn(err)
+        except Exception as err:
+            # TODO: more error handling
+            raise
+            log.error(err)
+        else:
+            # New key manager metadata checks out
+            trusted = untrusted
+            write_metadata_to_file(trusted, path)
+
+        # If key_mgr is unavailable from server, fall back to copy on disk
+        if not trusted and exists(path):
+            trusted = load_metadata_from_file(path)
+
+        return trusted
+
+    def __call__(self, record) -> Optional[str]:
+        # safety_checks must be enabled
+        # must have signatures to validate
+        if not context.extra_safety_checks or not getattr(record, "signatures", None):
+            return None
+
+        try:
+            verify_delegation('pkg_mgr', wrap_as_signable(record.info, record.signatures), self.key_mgr)
+        except SignatureError:
+            log.warn(f"invalid signature for {record.fn}")
+            return "(WARNING: metadata signature verification failed)"
+        else:
+            return "(INFO: package metadata is signed by Anaconda and trusted)"
+
+
+# singleton for caching
+metadata_signature_status = MetadataSignatureStatus()
+
+
+def fetch_channel_signing_data(signing_data_url, filename, etag=None, mod_stamp=None):
+    if not context.ssl_verify:
+        warnings.simplefilter('ignore', InsecureRequestWarning)
+
+    session = CondaSession()
+
+    headers = {
+        'Accept-Encoding': 'gzip, deflate, compress, identity',
+        'Content-Type': 'application/json',
+    }
+    if etag:
+        headers["If-None-Match"] = etag
+    if mod_stamp:
+        headers["If-Modified-Since"] = mod_stamp
+
+    try:
+        # The `auth` argument below looks a bit weird, but passing `None` seems
+        # insufficient for suppressing modifying the URL to add an Anaconda
+        # server token; for whatever reason, we must pass an actual callable in
+        # order to suppress the HTTP auth behavior configured in the session.
+        #
+        # TODO: Figure how to handle authn for obtaining trust metadata,
+        # independently of the authn used to access package repositories.
+        resp = session.get(
+            join_url(signing_data_url, filename),
+            headers=headers,
+            proxies=session.proxies,
+            auth=lambda r: r,
+            timeout=(context.remote_connect_timeout_secs, context.remote_read_timeout_secs),
+        )
+
+        resp.raise_for_status()
+    except:
+        # TODO: more sensible error handling
+        raise
+
+    # In certain cases (e.g., using `-c` access anaconda.org channels), the
+    # `CondaSession.get()` retry logic combined with the remote server's
+    # behavior can result in non-JSON content being returned.  Parse returned
+    # content here (rather than directly in the return statement) so callers of
+    # this function only have to worry about a ValueError being raised.
+    try:
+        str_data = json.loads(resp.content)
+    except json.decoder.JSONDecodeError as err:  # noqa
+        raise ValueError(f"Invalid JSON returned from {signing_data_url}/{filename}") from err
+
+    # TODO: additional loading and error handling improvements?
+
+    return str_data

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -82,8 +82,8 @@ SECURITY_METADATA_SPEC_VERSION = '0.6.0'
 # The only types we're allowed to wrap as "signables" and sign are
 # the JSON-serializable types.  (There are further constraints to what is
 # JSON-serializable in addition to these type constraints.)
-SUPPORTED_SERIALIZABLE_TYPES = [
-        dict, list, tuple, str, int, float, bool, type(None)]
+SUPPORTED_SERIALIZABLE_TYPES = (
+        dict, list, tuple, str, int, float, bool, type(None))
 
 # These are the permissible strings in the "type" field of delegating metadata.
 SUPPORTED_DELEGATING_METADATA_TYPES = ['root', 'key_mgr']  # May be loosened later.

--- a/conda_content_trust/constants.py
+++ b/conda_content_trust/constants.py
@@ -1,0 +1,46 @@
+# You could argue that the signatures being here is not necessary; indeed, we
+# are not necessarily going to be able to check them *properly* (based on some
+# prior expectations) as the user, since this is the beginning of trust
+# bootstrapping, the first/backup version of the root of trust metadata.
+# Still, the signatures here are useful for diagnostic purposes, and, more
+# important, to allow self-consistency checks: that helps us avoid breaking the
+# chain of trust if someone accidentally lists the wrong keys down the line. (:
+# The discrepancy can be detected when loading the root data, and we can
+# decline to cache incorrect trust metadata that would make further root
+# updates impossible.
+INITIAL_TRUST_ROOT = {
+    "signatures": {
+        "6d4d5888398ad77465e9fd53996309187723e16509144aa6733015c960378e7a": {
+            "other_headers": "04001608001d162104d2ca1d4bf5d77e7c312534284dd9c45328b685ec0502605dbb03",  # noqa: E501
+            "signature": "b71c9b3aa60e77258c402e574397127bcb4bc15ef3055ada8539b0d1e355bf1415a135fb7cecc9244f839a929f6b1f82844a5b3df8d6225ec9a50b181692490f",  # noqa: E501
+        },
+        "508debb915ede0b16dc0cff63f250bde73c5923317b44719fcfc25cc95560c44": {
+            "other_headers": "04001608001d162104e6dffee4638f24cfa60a08ba03afe1314a3a38fc050260621281",  # noqa: E501
+            "signature": "29d53d4e7dbea0a3efb07266d22e57cf4df7abe004453981c631245716e1b737c7a6b4ab95f42592af70be67abf56e97020e1aa1f52b49ef39b37481f05d5701",  # noqa: E501
+        },
+    },
+    "signed": {
+        "delegations": {
+            "key_mgr": {
+                "pubkeys": ["f24c813d23a9b26be665eee5c54680c35321061b337f862385ed6d783b0bedb0"],
+                "threshold": 1,
+            },
+            "root": {
+                "pubkeys": [
+                    "668a3217d72d4064edb16648435dc4a3e09a172ecee45dcab1464dcd2f402ec6",
+                    "508debb915ede0b16dc0cff63f250bde73c5923317b44719fcfc25cc95560c44",
+                    "6d4d5888398ad77465e9fd53996309187723e16509144aa6733015c960378e7a",
+                    "e0c88b4c0721bd451b7e720dfb0d0bb6b3853f0cbcf5570edd73367d0841be51",
+                ],
+                "threshold": 2,
+            },
+        },
+        "expiration": "2022-10-31T18:00:00Z",
+        "metadata_spec_version": "0.6.0",
+        "timestamp": "2021-03-26T00:00:00Z",
+        "type": "root",
+        "version": 1,
+    },
+}
+
+KEY_MGR_FILE = "key_mgr.json"

--- a/conda_content_trust/signing.py
+++ b/conda_content_trust/signing.py
@@ -74,7 +74,7 @@ def serialize_and_sign(obj, private_key):
 
 
 
-def wrap_as_signable(obj):
+def wrap_as_signable(obj, signatures=None):
     """
     Given a JSON-serializable object (dictionary, list, string, numeric, etc.),
     returns a wrapped copy of that object:
@@ -90,7 +90,7 @@ def wrap_as_signable(obj):
     Raises ❌TypeError if the given object is not a JSON-serializable type per
     SUPPORTED_SERIALIZABLE_TYPES
     """
-    if not type(obj) in SUPPORTED_SERIALIZABLE_TYPES:
+    if not isinstance(obj, SUPPORTED_SERIALIZABLE_TYPES):
         raise TypeError(
                 'wrap_dict_as_signable requires a JSON-serializable object, '
                 'but the given argument is of type ' + str(type(obj)) + ', '
@@ -103,7 +103,7 @@ def wrap_as_signable(obj):
     #          this way in TUF, but we also don't depend on it being an ordered
     #          list anyway, so a dictionary is probably better.
 
-    return {'signatures': {}, 'signed': copy.deepcopy(obj)}
+    return {'signatures': signatures or {}, 'signed': copy.deepcopy(obj)}
 
 
 


### PR DESCRIPTION
### Description

This transfers all signature verification logic embedded in conda itself to `conda-content-trust` in an effort to make verification more functional/lazy and to also simplify conda's logic by removing all caching etc. from conda and rather leaving that as a responsibility of conda-content-trust.

See conda/conda#11545