### PR TITLE
Add typing to `conda_content_trust.common`

### DIFF
--- a/conda_content_trust/authentication.py
+++ b/conda_content_trust/authentication.py
@@ -28,10 +28,10 @@ from .common import (
     checkformat_gpg_signature,
     checkformat_hex_key,
     checkformat_signable,
-    is_a_signable,
     is_gpg_signature,
     is_hex_key,
     is_hex_signature,
+    is_signable,
     is_signature,
 )
 
@@ -342,7 +342,7 @@ def verify_signable(signable, authorized_pub_keys, threshold, gpg=False):
     #       we'll mostly have the hex strings on hand, but....
 
     # Argument validation
-    if not is_a_signable(signable):
+    if not is_signable(signable):
         raise TypeError(
             "verify_signable expects a signable dictionary.  "
             "Given argument failed the test."

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -351,7 +351,7 @@ def is_hex_key(hex_key: Any) -> bool:
         return False
 
 
-def is_signable(dictionary):
+def is_signable(signable: Any) -> bool:
     """
     Returns True if the given dictionary is a signable dictionary as produced
     by wrap_as_signable.  Note that there MUST be no additional elements beyond
@@ -359,24 +359,21 @@ def is_signable(dictionary):
     outside the signed portion of the data should be the signatures; what's
     outside of 'signed' is under attacker control.)
     """
-    if (
-        isinstance(dictionary, dict)
-        and "signatures" in dictionary
-        and "signed" in dictionary
-        and isinstance(dictionary["signatures"], dict)  # , list)
-        and type(dictionary["signed"]) in SUPPORTED_SERIALIZABLE_TYPES
-        and len(dictionary) == 2
-    ):
-        return True
+    return (
+        isinstance(signable, dict)
+        and set(signable) == {"signatures", "signed"}
+        and isinstance(signable["signatures"], dict)
+        and type(signable["signed"]) in SUPPORTED_SERIALIZABLE_TYPES
+    )
 
-    else:
-        return False
+
+Signable = dict
 
 
 # TODO: ✅ Consolidate: switch to use of this wherever is_a_signable is called
 #          and then an error is raised if the result is False.
-def checkformat_signable(dictionary):
-    if not is_signable(dictionary):
+def checkformat_signable(signable: Any) -> Signable:
+    if not is_signable(signable):
         raise TypeError(
             "Expected a signable dictionary, but the given argument "
             "does not match expectations for a signable dictionary "
@@ -385,6 +382,8 @@ def checkformat_signable(dictionary):
             'and the value for key "signed" is a supported serializable '
             "type (" + str(SUPPORTED_SERIALIZABLE_TYPES) + ")"
         )
+
+    return signable
 
 
 def checkformat_byteslike(obj):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -45,11 +45,13 @@ Exceptions:
         MetadataVerificationError
         UnknownRoleError
 """
+from __future__ import annotations
+
 from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from json import dumps, load
 from re import compile  # for UTC iso8601 date string checking
-from typing import Any
+from typing import Annotated, Any
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -334,7 +336,7 @@ def is_hex_signature(hex_signature: Any) -> bool:
     return False
 
 
-def is_hex_key(key):
+def is_hex_key(hex_key: Any) -> bool:
     """
     Returns True if key is a hex string with no uppercase characters, no
     spaces, no '0x' prefix(es), etc., and is 64 hexadecimal characters (the
@@ -343,7 +345,7 @@ def is_hex_key(key):
     Else, returns False.
     """
     try:
-        checkformat_hex_key(key)
+        checkformat_hex_key(hex_key)
         return True
     except (TypeError, ValueError):
         return False
@@ -411,30 +413,37 @@ def checkformat_expiration_distance(expiration_distance):
         )
 
 
-def checkformat_hex_key(k):
-    checkformat_hex_string(k)
+HexKey = Annotated[HexString, "len() == 64"]
 
-    if 64 != len(k):
+
+def checkformat_hex_key(hex_key: Any) -> HexKey:
+    checkformat_hex_string(hex_key)
+
+    if 64 != len(hex_key):
         raise ValueError("Expected a 64-character hex string representing a key value.")
 
+    return hex_key
 
-def checkformat_list_of_hex_keys(value):
+
+def checkformat_list_of_hex_keys(list_of_hex_keys: Any) -> list[HexKey]:
     """
     Note that this rejects any list of keys that includes any exact duplicates.
     """
-    if not isinstance(value, list):
+    if not isinstance(list_of_hex_keys, list):
         raise TypeError(
             "Expected a list of 64-character hex strings representing keys."
         )
 
-    for key in value:
-        checkformat_hex_key(key)
+    for hex_key in list_of_hex_keys:
+        checkformat_hex_key(hex_key)
 
-    if len(set(value)) != len(value):
+    if len(set(list_of_hex_keys)) != len(list_of_hex_keys):
         raise ValueError(
             "The given list of keys in hex string form contains duplicates.  "
             "Duplicates are not permitted."
         )
+
+    return list_of_hex_keys
 
 
 def checkformat_utc_isoformat(s):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -643,7 +643,10 @@ def checkformat_signature(signature: Any) -> Signature:
         )
 
 
-def checkformat_delegation(delegation):
+Delegation = dict
+
+
+def checkformat_delegation(delegation: Any) -> Delegation:
     """
     A dictionary specifying public key values and threshold of keys
     e.g.
@@ -663,10 +666,8 @@ def checkformat_delegation(delegation):
             '"pubkeys" and "threshold" elements.'
         )
     elif not (
-        len(delegation) == 2
-        and "threshold" in delegation
+        set(delegation) == {"threshold", "pubkeys"}
         and delegation["threshold"] >= 1
-        and "pubkeys" in delegation
         and isinstance(delegation["pubkeys"], list)
         and all([is_hex_key(k) for k in delegation["pubkeys"]])
     ):
@@ -681,8 +682,10 @@ def checkformat_delegation(delegation):
     checkformat_list_of_hex_keys(delegation["pubkeys"])
     checkformat_natural_int(delegation["threshold"])
 
+    return delegation
 
-def checkformat_delegations(delegations):
+
+def checkformat_delegations(delegations: Any) -> dict[str, Delegation]:
     """
     A dictionary specifying a delegation for any number of role names.
     Index: rolename.  Value: delegation (see checkformat_delegation).
@@ -704,8 +707,13 @@ def checkformat_delegations(delegations):
         checkformat_string(index)
         checkformat_delegation(delegations[index])
 
+    return delegations
 
-def checkformat_delegating_metadata(metadata):
+
+DelegatingMetadata = Signable
+
+
+def checkformat_delegating_metadata(metadata: Any) -> DelegatingMetadata:
     """
     Validates argument "metadata" as delegating metadata.  Passes if it is,
     raises a TypeError or ValueError if it is not.

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -398,10 +398,12 @@ def checkformat_byteslike(byteslike: Any) -> BytesLike:
     return byteslike
 
 
-def checkformat_natural_int(number):
+def checkformat_natural_int(natural_int: Any) -> Annotated[int, ">= 1"]:
     # Technically a TypeError or ValueError, depending, but meh.
-    if int(number) != number or number < 1:
+    if int(natural_int) != natural_int or natural_int < 1:
         raise ValueError("Expected an integer >= 1.")
+
+    return natural_int
 
 
 # This is not yet widely used.

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -49,6 +49,7 @@ from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from json import dumps, load
 from re import compile  # for UTC iso8601 date string checking
+from typing import Any
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -288,30 +289,35 @@ class PublicKey(MixinKey, ed25519.Ed25519PublicKey):
 
 
 # ✅ TODO: Consider a schema definitions module, e.g. PyPI project "schema"
-def is_hex_string(s):
+def is_hex_string(hex_string: Any) -> bool:
     """
     Returns True if hex is a hex string with no uppercase characters, no spaces,
     etc.  Else, False.
     """
     try:
-        checkformat_hex_string(s)
+        checkformat_hex_string(hex_string)
         return True
     except (ValueError, TypeError):
         return False
 
 
-def checkformat_hex_string(s):
+HexString = str
+
+
+def checkformat_hex_string(hex_string: Any) -> HexString:
     """
     Throws TypeError if s is not a string.
     Throws ValueError if the given string is not a string of hexadecimal
     characters (upper-case not allowed to prevent redundancy).
     """
-    bytes.fromhex(s)
+    bytes.fromhex(hex_string)
     # isalnum() checks for no whitespace which bytes.fromhex() would allow.
-    if not s.isalnum() or s.lower() != s:
+    if not hex_string.isalnum() or hex_string.lower() != hex_string:
         raise ValueError(
             "Expected a hex string; non-hexadecimal or upper-case character found."
         )
+
+    return hex_string
 
 
 def is_hex_signature(sig):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -408,9 +408,11 @@ def checkformat_natural_int(natural_int: Any) -> Annotated[int, ">= 1"]:
 
 # This is not yet widely used.
 # TODO: ✅ See to it that anywhere we're checking for a string, we use this.
-def checkformat_string(s):
-    if not isinstance(s, str):
+def checkformat_string(string: Any) -> str:
+    if not isinstance(string, str):
         raise TypeError("Expecting a string")
+
+    return string
 
 
 def checkformat_expiration_distance(expiration_distance):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -51,7 +51,7 @@ from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from json import dumps, load
 from re import compile  # for UTC iso8601 date string checking
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -386,9 +386,16 @@ def checkformat_signable(signable: Any) -> Signable:
     return signable
 
 
-def checkformat_byteslike(obj):
-    if not hasattr(obj, "decode"):
+class BytesLike(Protocol):
+    def decode(self, *args, **kwargs) -> str:
+        ...
+
+
+def checkformat_byteslike(byteslike: Any) -> BytesLike:
+    if not hasattr(byteslike, "decode"):
         raise TypeError("Expected a bytes-like object with a decode method.")
+
+    return byteslike
 
 
 def checkformat_natural_int(number):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -463,26 +463,29 @@ def checkformat_utc_isoformat(date_string: Any) -> str:
     return date_string
 
 
-def is_gpg_fingerprint(fingerprint):
+def is_gpg_fingerprint(gpg_fingerprint: Any) -> bool:
     """
     True if the given value is a hex string of length 40 (representing a
     20-byte SHA-1 value, which is what OpenPGP/GPG uses as a key fingerprint).
     """
     try:
-        checkformat_gpg_fingerprint(fingerprint)
+        checkformat_gpg_fingerprint(gpg_fingerprint)
         return True
     except (TypeError, ValueError):
         return False
 
 
-def checkformat_gpg_fingerprint(fingerprint):
+GPGFingerprint = Annotated[HexKey, "len()==40"]
+
+
+def checkformat_gpg_fingerprint(gpg_fingerprint: Any) -> GPGFingerprint:
     """
     See is_gpg_fingerprint.  Raises a TypeError if is_gpg_fingerprint is not
     True.
     """
-    if len(fingerprint) != 40:
+    if len(gpg_fingerprint) != 40:
         raise ValueError(
-            'The given value, "' + str(fingerprint) + '", is not a full '
+            'The given value, "' + str(gpg_fingerprint) + '", is not a full '
             "GPG fingerprint (40 hex characters)."
         )
 
@@ -493,11 +496,13 @@ def checkformat_gpg_fingerprint(fingerprint):
     # same key -- with the key represented differently -- to count as two
     # signatures from distinct keys.
     # local hex test. isalnum() checks for no whitespace.
-    bytes.fromhex(fingerprint)
-    if not fingerprint.isalnum() or fingerprint.lower() != fingerprint:
+    bytes.fromhex(gpg_fingerprint)
+    if not gpg_fingerprint.isalnum() or gpg_fingerprint.lower() != gpg_fingerprint:
         raise ValueError(
             "Expected a hex string; non-hexadecimal or upper-case character found."
         )
+
+    return gpg_fingerprint
 
 
 def is_gpg_signature(gpg_signature: Any) -> bool:

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from json import dumps, load
-from typing import Annotated, Any, Protocol
+from typing import Any, Protocol
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -389,7 +389,7 @@ def checkformat_byteslike(byteslike: Any) -> BytesLike:
     return byteslike
 
 
-def checkformat_natural_int(natural_int: Any) -> Annotated[int, ">= 1"]:
+def checkformat_natural_int(natural_int: Any) -> int:  # Annotated[int, ">= 1"]
     # Technically a TypeError or ValueError, depending, but meh.
     if int(natural_int) != natural_int or natural_int < 1:
         raise ValueError("Expected an integer >= 1.")
@@ -416,7 +416,7 @@ def checkformat_expiration_distance(expiration_distance: Any) -> timedelta:
     return expiration_distance
 
 
-HexKey = Annotated[HexString, "len() == 64"]
+HexKey = HexString  # Annotated[HexString, "len() == 64"]
 
 
 def checkformat_hex_key(hex_key: Any) -> HexKey:
@@ -475,7 +475,7 @@ def is_gpg_fingerprint(gpg_fingerprint: Any) -> bool:
         return False
 
 
-GPGFingerprint = Annotated[HexKey, "len()==40"]
+GPGFingerprint = HexKey  # Annotated[HexKey, "len()==40"]
 
 
 def checkformat_gpg_fingerprint(gpg_fingerprint: Any) -> GPGFingerprint:

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -19,7 +19,7 @@ Formats and Validation:
   r  is_hex_key
   r  checkformat_hex_key
   r  checkformat_list_of_hex_keys
-  x  is_a_signable
+  x  is_signable
   x  checkformat_byteslike
   x  checkformat_natural_int
   x  checkformat_expiration_distance
@@ -343,7 +343,7 @@ def is_hex_key(key):
         return False
 
 
-def is_a_signable(dictionary):
+def is_signable(dictionary):
     """
     Returns True if the given dictionary is a signable dictionary as produced
     by wrap_as_signable.  Note that there MUST be no additional elements beyond
@@ -368,7 +368,7 @@ def is_a_signable(dictionary):
 # TODO: ✅ Consolidate: switch to use of this wherever is_a_signable is called
 #          and then an error is raised if the result is False.
 def checkformat_signable(dictionary):
-    if not is_a_signable(dictionary):
+    if not is_signable(dictionary):
         raise TypeError(
             "Expected a signable dictionary, but the given argument "
             "does not match expectations for a signable dictionary "

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -820,35 +820,6 @@ def checkformat_any_signature(sig):
         )
 
 
-# def sha512256(data):
-#     """
-#     # TODO ✅: Deprecate me in favor of simple SHA-256 hashing via
-#     #          pyca/cryptography.
-
-#     Since hashlib still does not provide a "SHA-512/256" option (SHA-512 with,
-#     basically, truncation to 256 bits at each stage of the hashing, defined by
-#     the FIPS Secure Hash Standard), we provide it here.  SHA-512/256 is as
-#     secure as SHA-256, but substantially faster on 64-bit architectures.
-#     Uses pyca/cryptography.
-
-#     Given bytes, returns the hex digest of the hash of the given bytes, using
-#     SHA-512/256.
-#     """
-#     if not isinstance(data, bytes):
-#         # Note that string literals in Python2 also pass this test by default.
-#         # unicode_literals fixes that for string literals created in modules
-#         # importing unicode_literals.
-#         raise TypeError('Expected bytes; received ' + str(type(data)))
-
-#     # pyca/cryptography's interface is a little clunky about this.
-#     hasher = cryptography.hazmat.primitives.hashes.Hash(
-#             algorithm=cryptography.hazmat.primitives.hashes.SHA512_256(),
-#             backend=cryptography.hazmat.backends.default_backend())
-#     hasher.update(data)
-
-#     return hasher.finalize().hex()
-
-
 def keyfiles_to_bytes(name):
     """
     Toy function.  Import an ed25519 key pair, in the forms of raw public and
@@ -885,50 +856,6 @@ def keyfiles_to_keys(name):
     return private, public
 
 
-# This function has been replaced by method to_bytes() in classes PublicKey
-# and PrivateKey (see class MixinKey).
-# def key_to_bytes(key):
-#     """
-#     Pops out the nice, tidy bytes of a given cryptography...ed25519 key obj,
-#     public or private.
-#     """
-#     if isinstance(key, ed25519.Ed25519PrivateKey):
-#         return key.private_bytes(
-#                 encoding=serialization.Encoding.Raw,
-#                 format=serialization.PrivateFormat.Raw,
-#                 encryption_algorithm=serialization.NoEncryption())
-#     elif isinstance(key, ed25519.Ed25519PublicKey):
-#         return key.public_bytes(
-#                 serialization.Encoding.Raw,
-#                 serialization.PublicFormat.Raw)
-#     else:
-#         raise TypeError(
-#                 'Can only handle objects of class Ed25519PrivateKey or '
-#                 'Ed25519PublicKey.  Given object is of class: ' +
-#                 str(type(key)))
-
-
-# This function has been replaced by method from_bytes() in classes PublicKey
-# and PrivateKey (see class MixinKey).
-# def public_key_from_bytes(public_bytes):
-#     # from_public_bytes() checks length (32), but does not produce helpful
-#     # errors if the argument provided it is not the right type.
-#     checkformat_byteslike(public_bytes)
-#     if len(public_bytes) != 32:
-#         raise ValueError('Requires bytes-like object of length 32.')
-#     return ed25519.Ed25519PublicKey.from_public_bytes(public_bytes)
-
-
-# This function has been replaced by method from_hex() in classes PublicKey and
-# PrivateKey (see class MixinKey).
-# def public_key_from_hex_string(public_hex_string):
-
-#     checkformat_hex_key(public_hex_string)
-
-#     return ed25519.Ed25519PublicKey.from_public_bytes(unhexlify(
-#             public_hex_string))
-
-
 def checkformat_key(key):
     """
     Enforces expectation that argument is an object of type
@@ -944,24 +871,6 @@ def checkformat_key(key):
             + str(type(key))
             + " instead."
         )
-
-
-# def signature
-# def bytes_to_hex_string():
-# def bytes_from_hex_string(hex):
-
-#     hexlify().
-
-# def public_key_from_hex_string(public_hex_string):
-#     return ed25519.Ed25519PublicKey.from_public_bytes(unhexlify(public_hex_string))
-
-# def private_key_from_bytes(private_bytes):
-#     # from_private_bytes() checks length (32), but does not produce helpful
-#     # errors if the argument provided it is not the right type.
-#     checkformat_byteslike(private_bytes)
-#     # if len(private_bytes) != 32:
-#     #     raise ValueError('Requires bytes-like object of length 32.')
-#     return ed25519.Ed25519PrivateKey.from_bytes(private_bytes)
 
 
 def iso8601_time_plus_delta(delta):
@@ -981,30 +890,3 @@ def iso8601_time_plus_delta(delta):
     unix_expiry = datetime.utcnow().replace(microsecond=0) + delta
 
     return unix_expiry.isoformat() + "Z"
-
-
-# This function should not be necessary, since we'll only be dealing with
-# signatures we generate, and we'll adapt them to our requirements when they're
-# made (just a few adjustments).
-# def _gpgsig_to_sslgpgsig(gpg_sig):
-#
-#     conda_content_trust.common.checkformat_gpg_signature(gpg_sig)
-#
-#     return {
-#             'keyid': copy.deepcopy(gpg_sig['key_fingerprint']),
-#             'other_headers': copy.deepcopy(gpg_sig[other_headers]),
-#             'signature': copy.deepcopy(gpg_sig['signature'])}
-
-
-# This function should not be necessary, since we'll only be dealing with
-# signatures we generate, and we'll adapt them to our requirements when they're
-# made (just a few adjustments).
-# def _sslgpgsig_to_gpgsig(ssl_gpg_sig):
-#
-#     securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(ssl_gpg_sig)
-#
-#     return {
-#             'key_fingerprint': copy.deepcopy(ssl_gpg_sig['keyid']),
-#             'other_headers': copy.deepcopy(ssl_gpg_sig[other_headers]),
-#             'signature': copy.depcopy(ssl_gpg_sig['signature'])
-#     }

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -874,21 +874,21 @@ def keyfiles_to_keys(name):
     return private, public
 
 
-def checkformat_key(key):
+def checkformat_key(key: Any) -> ed25519.Ed25519PublicKey | ed25519.Ed25519PrivateKey:
     """
     Enforces expectation that argument is an object of type
     cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey or
     cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey.
     """
-    if not isinstance(key, ed25519.Ed25519PublicKey) and not isinstance(
-        key, ed25519.Ed25519PrivateKey
-    ):
+    if not isinstance(key, (ed25519.Ed25519PublicKey, ed25519.Ed25519PrivateKey)):
         raise TypeError(
             "Expected an Ed25519PublicKey or Ed25519PrivateKey object "
             'from the "cryptography" library.  Received object of type '
             + str(type(key))
             + " instead."
         )
+
+    return key
 
 
 def iso8601_time_plus_delta(delta):

--- a/conda_content_trust/common.py
+++ b/conda_content_trust/common.py
@@ -541,7 +541,7 @@ def checkformat_gpg_signature(signature_obj):
         checkformat_gpg_fingerprint(signature_obj["see_also"])
 
 
-def is_a_signature(signature_obj):
+def is_signature(signature_obj):
     """
     Returns True if signature_obj is a dictionary representing an ed25519
     signature, either in the conda-content-trust normal format, or
@@ -612,19 +612,6 @@ def checkformat_signature(signature_obj):
             "signature object (neither simple ed25519 sig nor OpenPGP "
             "ed25519 sig)."
         )
-
-
-def is_signature(s):
-    """
-    True if the given value is a dictionary containing a 'signature' entry
-    with value set to a hex string of length 128 (representing an ed25519
-    signature).
-    """
-    try:
-        checkformat_signature(s)
-        return True
-    except (TypeError, ValueError):
-        return False
 
 
 def checkformat_delegation(delegation):
@@ -811,7 +798,7 @@ def checkformat_delegating_metadata(metadata):
 
 
 def checkformat_any_signature(sig):
-    if not is_a_signature(sig) and not is_gpg_signature(sig):
+    if not is_signature(sig) and not is_gpg_signature(sig):
         raise ValueError(
             "Expected either a hex string representing a raw ed25519 "
             "signature (see checkformat_signature) or a dictionary "

--- a/conda_content_trust/root_signing.py
+++ b/conda_content_trust/root_signing.py
@@ -39,7 +39,7 @@ from .common import (
     checkformat_gpg_fingerprint,
     checkformat_hex_key,
     checkformat_key,
-    is_a_signable,
+    is_signable,
     load_metadata_from_file,
     write_metadata_to_file,
 )
@@ -233,7 +233,7 @@ def sign_root_metadata_dict_via_gpg(root_signable, gpg_key_fingerprint):
         )
 
     # Make sure it's the right format.
-    if not is_a_signable(root_signable):
+    if not is_signable(root_signable):
         raise TypeError(
             "Expected a signable dictionary; the given file "
             + str(root_md_fname)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -27,8 +27,8 @@ from conda_content_trust.common import (
     PublicKey,
     SignatureError,
     UnknownRoleError,
-    is_a_signable,
     is_hex_key,
+    is_signable,
     keyfiles_to_bytes,
     keyfiles_to_keys,
 )
@@ -192,9 +192,9 @@ def test_wrap_sign_verify_signable():
     d = {"foo": "bar", "1": 2}
     d_modified = {"foo": "DOOM", "1": 2}
     signable_d = wrap_as_signable(d)
-    assert is_a_signable(signable_d)
+    assert is_signable(signable_d)
     sign_signable(signable_d, old_private)
-    assert is_a_signable(signable_d)
+    assert is_signable(signable_d)
 
     verify_signable(
         signable=signable_d,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -29,10 +29,10 @@ from conda_content_trust.common import (
     checkformat_signature,
     checkformat_string,
     ed25519,
-    is_a_signature,
     is_gpg_fingerprint,
     is_gpg_signature,
     is_hex_key,
+    is_signature,
     keyfiles_to_bytes,
     keyfiles_to_keys,
 )
@@ -375,7 +375,7 @@ def test_is_gpg_signature():
         checkformat_gpg_signature(sig)
         checkformat_signature(sig)
         assert is_gpg_signature(sig)
-        assert is_a_signature(sig)
+        assert is_signature(sig)
 
     def expect_failure(sig, exception_class):
         with pytest.raises(exception_class):
@@ -383,7 +383,7 @@ def test_is_gpg_signature():
         with pytest.raises(exception_class):
             checkformat_signature(sig)
         assert not is_gpg_signature(sig)
-        assert not is_a_signature(sig)
+        assert not is_signature(sig)
 
     gpg_sig = {
         "other_headers": "04001608001d162104f075dd2f6f4cb3bd76134bbb81b6ca16ef9cd58905025defd3d3",

--- a/tests/test_metadata_construction.py
+++ b/tests/test_metadata_construction.py
@@ -21,7 +21,7 @@ from conda_content_trust.common import (
     PrivateKey,
     PublicKey,
     checkformat_delegating_metadata,
-    is_a_signable,
+    is_signable,
     keyfiles_to_bytes,
     keyfiles_to_keys,
 )
@@ -208,9 +208,9 @@ def test_build_root_metadata():
             root_timestamp=TEST_TIMESTAMP,
         )
 
-    assert not is_a_signable(root_md)
+    assert not is_signable(root_md)
     signable_root_md = wrap_as_signable(root_md)
-    assert is_a_signable(signable_root_md)
+    assert is_signable(signable_root_md)
 
 
 def test_build_delegating_metadata():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Changes

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

- Adds typing to all `checkformat_*` and `is_*` functions
- Converts all checkformat function into passthrough functions (for cleaner code elsewhere, TBD)
- Drop `is_a_signature` in favor of identical `is_signature`
- Rename `is_a_signable` to `is_signable` (for consistent naming)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
