### PR TITLE
Don't re-run the tests upon canary build.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ test:
     - pytest-cov
     - ruamel_yaml
   commands:
-    - pytest -v tests
     - conda-content-trust --help
 
 about:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,6 @@
 cryptography>=41.0.0
 pytest
 pytest-cov
-pytest-mock
 conda>=22.11
 conda-forge::securesystemslib
 setuptools_scm

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -28,11 +28,13 @@ try:
 except ImportError:
     SSLIB_AVAILABLE = False
 
-import conda_content_trust.authentication as authentication
-import conda_content_trust.common as common
-import conda_content_trust.metadata_construction as metadata_construction
-import conda_content_trust.root_signing as root_signing
-import conda_content_trust.signing as signing
+from conda_content_trust import (
+    authentication,
+    common,
+    metadata_construction,
+    root_signing,
+    signing,
+)
 
 # Note that changing these sample values breaks the sample signature, so you'd
 # have to generate a new one.
@@ -233,11 +235,11 @@ def test_check_sslib_available():
         root_signing._check_sslib_available()
 
 
-def test_no_sslib(mocker):
+def test_no_sslib(monkeypatch):
     """
     Coverage for "we don't have sslib" exceptions.
     """
-    mocker.patch("conda_content_trust.root_signing.SSLIB_AVAILABLE", False)
+    monkeypatch.setattr(root_signing, "SSLIB_AVAILABLE", False)
     with pytest.raises(Exception, match="securesystemslib"):
         root_signing.sign_via_gpg(None, None)  # type: ignore
     with pytest.raises(Exception, match="securesystemslib"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fixing canary build triggered by the fact that it was re-running the test suite, without listing the new `securesystemslib` dependency added in #75 in the recipe metadata.

Removing the test run from the metadata since we usually just run pytest directly instead of using conda-build for that.

At the same time also converted a test to use the monkeypatch fixture

Canary build action run: https://github.com/conda/conda-content-trust/actions/runs/5944287692/job/16123059665

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
