### PR TITLE
Fix `conda.plugins` import

### DIFF
--- a/conda_content_trust/plugin.py
+++ b/conda_content_trust/plugin.py
@@ -9,7 +9,7 @@ This module registers:
 Note: The signature verification hook was migrated from conda.trust in conda 26.3.
 """
 
-import conda.plugins.hookimpl
+import conda.plugins
 import conda.plugins.types
 
 from .cli import cli

--- a/news/260-fix-import
+++ b/news/260-fix-import
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `conda.plugins` import. (#260)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda.plugins.hookimpl` is not a valid import.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-content-trust/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-content-trust/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-content-trust/blob/main/CONTRIBUTING.md -->
