### PR TITLE
Backport #265: Fix AttributeError on cryptography>=44 in verify_gpg_signature

### DIFF
--- a/conda_content_trust/authentication.py
+++ b/conda_content_trust/authentication.py
@@ -15,6 +15,7 @@ Function Manifest for this Module
 from struct import pack
 
 import cryptography.exceptions
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from .common import (
@@ -517,10 +518,14 @@ def verify_gpg_signature(signature, key_value, data):
 
     # As per RFC4880 Section 5.2.4., we need to hash the content,
     # signature headers and add a very opinionated trailing header
-    hasher = cryptography.hazmat.primitives.hashes.Hash(
-        cryptography.hazmat.primitives.hashes.SHA256(),
-        cryptography.hazmat.backends.default_backend(),
-    )
+    # ``Hash``'s ``backend`` argument has been optional since cryptography
+    # 3.1. Previously this passed ``cryptography.hazmat.backends.default_backend()``
+    # without importing ``cryptography.hazmat.backends``; that worked only
+    # because Ed25519PrivateKey.generate() on cryptography <= 43 transitively
+    # loaded the backends submodule. On cryptography >= 44, Ed25519 is
+    # Rust-only and no longer does so, causing ``AttributeError: module
+    # 'cryptography.hazmat' has no attribute 'backends'`` at this call site.
+    hasher = hashes.Hash(hashes.SHA256())
     hasher.update(data)
     hasher.update(additional_header_data)
     hasher.update(b"\x04\xff")

--- a/news/264-fix-cryptography-hazmat-backends-attributeerror
+++ b/news/264-fix-cryptography-hazmat-backends-attributeerror
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `AttributeError: module 'cryptography.hazmat' has no attribute 'backends'` in `verify_gpg_signature` (and therefore `verify_root` and `verify_signable(..., gpg=True)`) on `cryptography >= 44`. The function now imports `cryptography.hazmat.primitives.hashes` explicitly and drops the unused `backend=` argument to `Hash()`. (#264)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -11,13 +11,17 @@ Run the tests this way:
 import copy
 import json
 import os
+import struct
 from pathlib import Path
 
 import cryptography.exceptions
 import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from conda_content_trust.authentication import (
     verify_delegation,
+    verify_gpg_signature,
     verify_root,
     verify_signable,
     verify_signature,
@@ -553,3 +557,99 @@ def test_verify_signable_coverage():
     # gpg and signature that doesn't look like a gpg signature
     with pytest.raises(SignatureError, match="from at least"):
         verify_signable(signable_d, [HEX_KEY], 1, gpg=True)
+
+
+def _build_gpg_signature(
+    priv: ed25519.Ed25519PrivateKey,
+    data: bytes,
+    other_headers_bytes: bytes = b"\x04\x13\x01\x00",
+) -> tuple[str, dict]:
+    """Construct ``(pubkey_hex, signature)`` in the shape ``verify_gpg_signature`` expects."""
+    pubkey_hex = (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        .hex()
+    )
+    # Digest construction per RFC4880 Section 5.2.4 (EdDSA).
+    hasher = hashes.Hash(hashes.SHA256())
+    hasher.update(data)
+    hasher.update(other_headers_bytes)
+    hasher.update(b"\x04\xff")
+    hasher.update(struct.pack(">I", len(other_headers_bytes)))
+    digest = hasher.finalize()
+    return pubkey_hex, {
+        "other_headers": other_headers_bytes.hex(),
+        "signature": priv.sign(digest).hex(),
+    }
+
+
+def test_verify_gpg_signature_valid():
+    """A valid OpenPGP-style ed25519 signature verifies."""
+    priv = ed25519.Ed25519PrivateKey.generate()
+    data = b"conda-content-trust: verify_gpg_signature positive test"
+    pubkey_hex, signature = _build_gpg_signature(priv, data)
+
+    verify_gpg_signature(signature, pubkey_hex, data)
+
+
+def _corrupt_last_hex_char(hex_str: str) -> str:
+    return hex_str[:-1] + ("0" if hex_str[-1] != "0" else "1")
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(
+            lambda sig, pub, data: (sig, pub, data + b"!"),
+            id="tampered-data",
+        ),
+        pytest.param(
+            lambda sig, pub, data: (
+                {**sig, "signature": _corrupt_last_hex_char(sig["signature"])},
+                pub,
+                data,
+            ),
+            id="tampered-signature",
+        ),
+        pytest.param(
+            lambda sig, pub, data: (
+                sig,
+                _build_gpg_signature(ed25519.Ed25519PrivateKey.generate(), data)[0],
+                data,
+            ),
+            id="wrong-pubkey",
+        ),
+    ],
+)
+def test_verify_gpg_signature_invalid(mutate):
+    """Tampering with payload, signature, or public key raises ``InvalidSignature``."""
+    priv = ed25519.Ed25519PrivateKey.generate()
+    data = b"conda-content-trust: verify_gpg_signature negative test"
+    pubkey_hex, signature = _build_gpg_signature(priv, data)
+
+    bad_signature, bad_pubkey_hex, bad_data = mutate(signature, pubkey_hex, data)
+
+    with pytest.raises(cryptography.exceptions.InvalidSignature):
+        verify_gpg_signature(bad_signature, bad_pubkey_hex, bad_data)
+
+
+def test_verify_gpg_signature_does_not_rely_on_transitive_backends_import(
+    monkeypatch,
+):
+    """Regression: ``verify_gpg_signature`` must not depend on other code setting ``cryptography.hazmat.backends`` first (fails on cryptography >= 44)."""
+    import cryptography.hazmat
+
+    priv = ed25519.Ed25519PrivateKey.generate()
+    data = b"conda-content-trust: transitive-backends regression test"
+    pubkey_hex, signature = _build_gpg_signature(priv, data)
+
+    # Simulate a fresh interpreter on cryptography>=44: the ``backends``
+    # attribute is only set on ``cryptography.hazmat`` when something
+    # explicitly does ``import cryptography.hazmat.backends``, which
+    # conda-content-trust must not rely on.
+    monkeypatch.delattr(cryptography.hazmat, "backends", raising=False)
+
+    verify_gpg_signature(signature, pubkey_hex, data)


### PR DESCRIPTION
### Description

Cherry-picks #265 (`795ce9c`) onto `0.3.x` in preparation for the `0.3.2` patch release.

See #264 for the bug analysis and #265 for the full PR discussion. This branch is identical to the `main` merge commit of #265 — no conflicts, no changes.

Xref #266.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory~ — already included in the cherry-picked commit (`news/264-fix-cryptography-hazmat-backends-attributeerror`).
- [x] ~Add / update necessary tests?~ — already included in the cherry-picked commit.
- [x] ~Add / update outdated documentation?~ — no user-facing docs impacted.
